### PR TITLE
Update $router->currentRouteName() method to $router->current() - Larave...

### DIFF
--- a/src/Intouch/LaravelNewrelic/LaravelNewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/LaravelNewrelicServiceProvider.php
@@ -83,7 +83,7 @@ class LaravelNewrelicServiceProvider extends ServiceProvider
                     /** @var \Intouch\Newrelic\Newrelic $newrelic */
                     $newrelic = $app['newrelic'];
 
-                    $newrelic->nameTransaction( $router->currentRouteName() );
+                    $newrelic->nameTransaction( $router->current() );
                 }
             }
         );


### PR DESCRIPTION
...l 4.1

After upgrading to Laravel 4.1 I was getting `Call to undefined method Illuminate\Routing\Router::currentRouteName().` 
According to the docs the method name is changed to `current()`.
Check http://laravel.com/docs/upgrade#upgrade-4.1.

By changing the method name to `current()` I don't get the exception anymore so hopefully this fixes the problem.
