### PR TITLE
Revert back to `currentRouteName()`

### DIFF
--- a/src/Intouch/LaravelNewrelic/LaravelNewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/LaravelNewrelicServiceProvider.php
@@ -83,7 +83,7 @@ class LaravelNewrelicServiceProvider extends ServiceProvider
                     /** @var \Intouch\Newrelic\Newrelic $newrelic */
                     $newrelic = $app['newrelic'];
 
-                    $newrelic->nameTransaction( $router->current() );
+                    $newrelic->nameTransaction( $router->currentRouteName() );
                 }
             }
         );


### PR DESCRIPTION
As noted in the commit https://github.com/In-Touch/laravel-newrelic/commit/5354361b7fa3c05bb32e4a5b5275bd7669794332 the patch doesn't work. 
There was a bug in Laravel 4.1, they added back the method `currentRouteName()` to the Router class
laravel/framework@45ff48321ea625f6997d5d1b13dfec59f0dc08a3
