### PR TITLE
Update automatic transaction naming - closes #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,16 @@ Finally, publish the default configuration (it will end up in `app/config/packag
 
 * type: bool
 * default: true
-* this will automatically name all transactions by their route name
-    * ex: Route::get('foo/{id}/bar/{name}', ...) will be named: 'get foo/{id}/bar/{name}'
-    * the uri parameters will not be replaced, it will be the string literal
+* this will automatically name all transactions with the following precedence
+    1. Route name (e.g. "home")
+    2. Controller and method (e.g. "HomeController@showWelcome")
+    3. HTTP verb + path (e.g. "GET /")
+
+=> **name_provider**
+
+* type: closure or null
+* default: null
+* if a closure is provided, this allows for full customization of the transaction name with access to \Illuminate\Http\Request, \Illuminate\Http\Response and \Illuminate\Foundation\Application as parameters for convenience.
 
 => **throw_if_not_installed**
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -10,9 +10,20 @@ return array(
 
     /*
      * Will automatically name transactions in NewRelic,
-     * using the Laravel route name
+     * using the Laravel route name, action or request
      */
     'auto_name_transactions' => true,
+
+    /*
+     * Define the name provider used when automatically naming transactions.
+     * Accepts either a closure or null to use the package default.
+     */
+    'name_provider' => null,
+
+    // 'name_provider' => function ($request, $response, $app) {
+    //     return $app['router']->currentRouteAction()
+    //         ?: $request->getMethod() . ' ' . $request->getPathInfo();
+    // },
 
     /*
      * Will cause an exception to be thrown if the NewRelic


### PR DESCRIPTION
A few fixes for how updates to Laravel 4.1 affected transaction naming
as well as support for custom name providers via a closure callback.

More details: https://github.com/In-Touch/laravel-newrelic/issues/6
