### PR TITLE
PHP 5.3 transaction names via closure - fixes #8

### DIFF
--- a/src/Intouch/LaravelNewrelic/LaravelNewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/LaravelNewrelicServiceProvider.php
@@ -78,38 +78,25 @@ class LaravelNewrelicServiceProvider extends ServiceProvider
             {
                 if ( true == $app['config']['laravel-newrelic::auto_name_transactions'] )
                 {
+                    $nameProvider = $app['config']['laravel-newrelic::name_provider'];
+
+                    if ( is_callable( $nameProvider ) ) {
+                        $name = $nameProvider( $request, $response, $app );
+                    } else {
+                        /** @var \Illuminate\Routing\Router $router */
+                        $router = $app['router'];
+
+                        $name = $router->currentRouteName()
+                            ?: $router->currentRouteAction()
+                            ?: $request->getMethod() . ' ' . $request->getPathInfo();
+                    }
+
                     /** @var \Intouch\Newrelic\Newrelic $newrelic */
                     $newrelic = $app['newrelic'];
 
-                    $newrelic->nameTransaction( $this->getTransactionName( $request, $response, $app ) );
+                    $newrelic->nameTransaction( $name );
                 }
             }
         );
-    }
-
-    /**
-     * Build the transaction name
-     *
-     * @param  \Illuminate\Http\Request           $request
-     * @param  \Illuminate\Http\Response          $response
-     * @param  \Illuminate\Foundation\Application $app
-     * @return string
-     */
-    protected function getTransactionName( $request, $response, $app )
-    {
-        $nameProvider = $app['config']['laravel-newrelic::name_provider'];
-
-        if ( is_callable( $nameProvider ) ) {
-            $name = $nameProvider( $request, $response, $app );
-        } else {
-            /** @var \Illuminate\Routing\Router $router */
-            $router = $app['router'];
-
-            $name = $router->currentRouteName()
-                ?: $router->currentRouteAction()
-                ?: $request->getMethod() . ' ' . $request->getPathInfo();
-        }
-
-        return $name;
     }
 }


### PR DESCRIPTION
PHP 5.3 does not support using $this in closures. This fixes the issue
by moving the logic out of its own method directly into the closure
itself. We lose a bit of abstraction by doing this but it's not overly
complex to start with.
