### PR TITLE
Check if there is a current route defined before getting the action

### DIFF
--- a/src/Intouch/LaravelNewrelic/LaravelNewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/LaravelNewrelicServiceProvider.php
@@ -107,7 +107,7 @@ class LaravelNewrelicServiceProvider extends ServiceProvider
             $router = $app['router'];
 
             $name = $router->currentRouteName()
-                ?: $router->currentRouteAction()
+                ?: $router->current() && $router->currentRouteAction()
                 ?: $request->getMethod() . ' ' . $request->getPathInfo();
         }
 


### PR DESCRIPTION
This fixes an issue I discovered when a Laravel before filter returns a response.
