### PR TITLE
Fixed for non-default app namespace

### DIFF
--- a/src/Intouch/LaravelNewrelic/LumenNewrelicMiddleware.php
+++ b/src/Intouch/LaravelNewrelic/LumenNewrelicMiddleware.php
@@ -91,7 +91,7 @@ class LumenNewrelicMiddleware
 		};
 
 		$routes = [];
-		foreach (\App::getRoutes() as $routeName => $route) {
+		foreach (app()->getRoutes() as $routeName => $route) {
 			$regex = $routeToRegex($routeName);
 			$method = $routeToMethod($routeName);
 			$routes[$method.$regex] = compact('route', 'method', 'regex');


### PR DESCRIPTION
If we use some other namespace for our application we have a exception \App class not found. Please use app() helper function.