### PR TITLE
Update install instructions with full semantic version

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,12 @@ See the table above for package version information, and change the version belo
 
 Using `composer`, run:
 
-    composer require intouch/laravel-newrelic:"~2.0"
+    composer require intouch/laravel-newrelic:"~2.0.0"
 
 Or add `intouch/laravel-newrelic` to your composer requirements:
 
     "require": {
-        "intouch/laravel-newrelic": "~2.0"
+        "intouch/laravel-newrelic": "~2.0.0"
     }
 
 ... and then run `composer install`


### PR DESCRIPTION
Using fully semantic version (i.e., MAJOR.MINOR.PATCH) to avoid break changes.

I suggest to use the full semantic version to guarantee backwards compatibility during composer auto updates (`composer update`). Note that even a minor change may introduce break changes since version for Laravel 5.1 (2.0.0) isn't compatible with version for Laravel 5.2 (2.1.0).

~2.0 allows anything up to, but not including, 3.0
