### PR TITLE
Change the default newrelic.name_provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `newrelic.name_provider` config parameter holds this string - note that non-
 | {path}       | Registered route path                       | /users/{id?} |
 | {uri}        | Request URI path                            | /users/12345 |
 
-The default `newrelic.name_provider` string is `'{uri} {route}'`.
+The default `newrelic.name_provider` string is `'{controller}'`.
 
 ## Eloquent Model Observers
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -31,7 +31,7 @@ return array(
 	 *          "GET /world" with pattern 'hello {path} you really {method} me' would return:
 	 *          'hello /world you really GET me'
 	 */
-	'name_provider' => env('NEWRELIC_NAME_PROVIDER', '{uri} {route}'),
+	'name_provider' => env('NEWRELIC_NAME_PROVIDER', '{controller}'),
 
 	/*
 	 * Will cause an exception to be thrown if the NewRelic


### PR DESCRIPTION
This is a better practice, the previous default was explicitly recommended against in New Relic's documentation:

> You have /product/123 and /product/234. If you generate a separate transaction name for each, then New Relic will store separate information for these two transaction names.
> 
> Instead, store the transaction as /product/*, or use something significant about the code itself to name the transaction, such as /Product/view. The total number of unique transaction names should be less than 1000. Exceeding that is not recommended.
> 
> In MVC frameworks, one good option is to use the newrelic_name_transaction() call where your request is routed and name your transaction with a format of Controller / Action.
> 
> Unique values like URLs, Page Titles, Hex Values, Session IDs and uniquely identifiable values should not be used in naming your transactions, but instead tagged to the transaction as a custom parameter. See newrelic_add_custom_parameter() API function.
