### PR TITLE
Add support for Queued Job transactions

### DIFF
--- a/src/Intouch/LaravelNewrelic/NewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/NewrelicServiceProvider.php
@@ -16,6 +16,7 @@
  */
 namespace Intouch\LaravelNewrelic;
 
+use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\ServiceProvider;
 use Intouch\Newrelic\Newrelic;
@@ -42,6 +43,7 @@ class NewrelicServiceProvider extends ServiceProvider
 		$this->publishes( [ $config => config_path( 'newrelic.php' ) ], 'config' );
 
 		$this->registerNamedTransactions();
+		$this->registerQueueTransactions();
 	}
 
 	/**
@@ -83,6 +85,26 @@ class NewrelicServiceProvider extends ServiceProvider
 	}
 
 	/**
+	 * Registers the queue transactions with the NewRelic PHP agent
+	 */
+	protected function registerQueueTransactions()
+	{
+		$app = $this->app;
+
+		$app['queue']->before(function (JobProcessed $event) use ( $app ) {
+			$app['newrelic']->backgroundJob( true );
+			$app['newrelic']->startTransaction( ini_get('newrelic.appname') );
+			if ($app['config']->get( 'newrelic.auto_name_jobs' )) {
+				$app['newrelic']->nameTransaction( $this->getJobName($event) );
+			}
+		});
+
+		$app['queue']->after(function (JobProcessed $event) use ( $app ) {
+			$app['newrelic']->endTransaction();
+		});
+	}
+
+	/**
 	 * Build the transaction name
 	 *
 	 * @return string
@@ -105,6 +127,32 @@ class NewrelicServiceProvider extends ServiceProvider
 			    $this->getUri(),
 			],
 			$this->app['config']->get( 'newrelic.name_provider' )
+		);
+	}
+
+	/**
+	 * Build the job name
+	 *
+	 * @return string
+	 */
+	public function getJobName(JobProcessed $event)
+	{
+		return str_replace(
+			[
+			    '{connection}',
+			    '{class}',
+			    '{data}',
+			    '{args}',
+			    '{input}',
+			],
+			[
+			    $event->connectionName,
+			    get_class($event->job),
+			    json_encode($event->data),
+			    implode(', ', array_keys($event->data)),
+			    implode(', ', array_values($event->data)),
+			],
+			$this->app['config']->get( 'newrelic.job_name_provider' )
 		);
 	}
 

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -18,6 +18,15 @@ return array(
 	'auto_name_transactions' => env('NEWRELIC_AUTO_NAME_TRANSACTION', true),
 
 	/*
+	 * Will automatically name queued jobs in NewRelic,
+	 * using the Laravel job class, data, or connection name.
+	 *
+	 * Set this to false to use the NewRelic default naming
+	 * scheme, or to set your own in your application.
+	 */
+	'auto_name_jobs' => env('NEWRELIC_AUTO_NAME_JOB', true),
+
+	/*
 	 * Define the name used when automatically naming transactions.
 	 * a token string:
 	 *      a pattern you define yourself, available tokens:
@@ -32,6 +41,23 @@ return array(
 	 *          'hello /world you really GET me'
 	 */
 	'name_provider' => env('NEWRELIC_NAME_PROVIDER', '{uri} {route}'),
+
+	/*
+	 * Define the name used when automatically naming queued jobs.
+	 * a token string:
+	 *      a pattern you define yourself, available tokens:
+	 *          {connection} = The name of the queue connection
+	 *          {class} = The name of the job class
+	 *          {data} = JSON string with all data passed to the job
+	 *          {args} = List of variable names passed to the job
+	 *          {input} = List of values passed to the job
+	 *      anything that is not a matched token will remain a string literal
+	 *      example:
+	 *          Given a job named App\MyJob, with data {"subject":"hello","to":"world"},
+	 *			the pattern 'I say {input} when I run {class}' would return:
+	 *			'I say hello, world when I run App\MyJob'
+	 */
+	'job_name_provider' => env('NEWRELIC_JOB_NAME_PROVIDER', '{class}'),
 
 	/*
 	 * Will cause an exception to be thrown if the NewRelic


### PR DESCRIPTION
Queued jobs should also have intelligent naming, and be marked properly as background tasks.