### PR TITLE
feat: Run `nameTransaction` on `router.matched` 

### DIFF
--- a/src/Intouch/LaravelNewrelic/NewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/NewrelicServiceProvider.php
@@ -74,8 +74,8 @@ class NewrelicServiceProvider extends ServiceProvider
 	{
 		$me  = $this;
 		$app = $this->app;
-		$app['router']->after(
-			function ( $request, $response ) use ( $me ) {
+		$app['router']->matched(
+			function ( ) use ( $me ) {
 				if (true == $me->app['config']->get( 'newrelic.auto_name_transactions' )) {
 					$me->app['newrelic']->nameTransaction( $me->getTransactionName() );
 				}


### PR DESCRIPTION
This change updates the 5.0/5.1 branch to run on the `router.matched` event, rather than after the router. This will cause exceptions to be properly named as `nameTransactions` will have run before, rather than causing this to never run.

This is essentially a backport of the implementation in the versions for newer versions of Laravel.