### PR TITLE
Lumen 5.5 - Fix application routes loop

### DIFF
--- a/src/Intouch/LaravelNewrelic/LumenNewrelicMiddleware.php
+++ b/src/Intouch/LaravelNewrelic/LumenNewrelicMiddleware.php
@@ -91,7 +91,7 @@ class LumenNewrelicMiddleware
 		};
 
 		$routes = [];
-		foreach (app()->getRoutes() as $routeName => $route) {
+		foreach (app()->router->getRoutes() as $routeName => $route) {
 			$regex = $routeToRegex($routeName);
 			$method = $routeToMethod($routeName);
 			$routes[$method.$regex] = compact('route', 'method', 'regex');

--- a/src/Intouch/LaravelNewrelic/LumenNewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/LumenNewrelicServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Intouch\LaravelNewrelic;
 
+use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Support\ServiceProvider;
 use Intouch\Newrelic\Newrelic;
@@ -23,7 +24,7 @@ class LumenNewrelicServiceProvider extends ServiceProvider
 			}
 		);
 
-		app('queue')->before(function (JobProcessed $event) {
+		app('queue')->before(function (JobProcessing $event) {
 			app('newrelic')->backgroundJob( true );
 			app('newrelic')->startTransaction( ini_get('newrelic.appname') );
 			if (app('config')->get( 'newrelic.auto_name_jobs' )) {


### PR DESCRIPTION
Using Lumen 5.5 `app()->getRoutes()` no longer works, the method needs to be called directly on the router