### PR TITLE
 Fix queue transaction listeners to work with Laravel/Lumen 5.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 | Laravel Version | Package Tag | Supported |
 |-----------------|-------------|-----------|
-| 5.7.x | ? | yes |
-| 5.4.x | 2.2.x | yes |
+| 5.x.x | 2.2.x | yes |
 | 5.2.x | 2.1.x | yes |
 | 5.1.x | 2.0.x | yes |
 | 5.0.x | 2.0.x | no |

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 | Laravel Version | Package Tag | Supported |
 |-----------------|-------------|-----------|
+| 5.7.x | ? | yes |
 | 5.4.x | 2.2.x | yes |
 | 5.2.x | 2.1.x | yes |
 | 5.1.x | 2.0.x | yes |

--- a/src/Intouch/LaravelNewrelic/NewrelicServiceProvider.php
+++ b/src/Intouch/LaravelNewrelic/NewrelicServiceProvider.php
@@ -17,6 +17,7 @@
 namespace Intouch\LaravelNewrelic;
 
 use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\ServiceProvider;
 use Intouch\Newrelic\Newrelic;
@@ -24,192 +25,187 @@ use Intouch\Newrelic\Newrelic;
 class NewrelicServiceProvider extends ServiceProvider
 {
 
-	/**
-	 * Indicates if loading of the provider is deferred.
-	 *
-	 * @var bool
-	 */
-	protected $defer = false;
+    /**
+     * Indicates if loading of the provider is deferred.
+     *
+     * @var bool
+     */
+    protected $defer = false;
 
-	/**
-	 * Bootstrap the application events.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
-		$config = realpath( __DIR__ . '/../../config/config.php' );
-		$this->mergeConfigFrom( $config, 'newrelic' );
-		$this->publishes( [ $config => config_path( 'newrelic.php' ) ], 'config' );
+    /**
+     * Bootstrap the application events.
+     *
+     * @return void
+     */
+    public function boot()
+    {
+        $config = realpath( __DIR__ . '/../../config/config.php' );
+        $this->mergeConfigFrom( $config, 'newrelic' );
+        $this->publishes( [ $config => config_path( 'newrelic.php' ) ], 'config' );
 
-		$this->registerNamedTransactions();
-		$this->registerQueueTransactions();
-	}
+        $this->registerNamedTransactions();
+        $this->registerQueueTransactions();
+    }
 
-	/**
-	 * Register the service provider.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
-		$this->app->singleton(
-			'newrelic',
-			function ( $app ) {
-				return new Newrelic( $app['config']->get( 'newrelic.throw_if_not_installed' ) );
-			}
-		);
-	}
+    /**
+     * Register the service provider.
+     *
+     * @return void
+     */
+    public function register()
+    {
+        $this->app->singleton(
+            'newrelic',
+            function ( $app ) {
+                return new Newrelic( $app['config']->get( 'newrelic.throw_if_not_installed' ) );
+            }
+        );
+    }
 
-	/**
-	 * Get the services provided by the provider.
-	 *
-	 * @return array
-	 */
-	public function provides()
-	{
-		return [ 'newrelic' ];
-	}
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [ 'newrelic' ];
+    }
 
-	/**
-	 * Registers the named transactions with the NewRelic PHP agent
-	 */
-	protected function registerNamedTransactions()
-	{
-		$app = $this->app;
+    /**
+     * Registers the named transactions with the NewRelic PHP agent
+     */
+    protected function registerNamedTransactions()
+    {
+        $app = $this->app;
 
-		if ($app['config']->get( 'newrelic.auto_name_transactions' )) {
-			$app['events']->listen(RouteMatched::class, function (RouteMatched $routeMatched) use ( $app ) {
-				$app['newrelic']->nameTransaction( $this->getTransactionName() );
-			});
-		}
-	}
+        if ($app['config']->get( 'newrelic.auto_name_transactions' )) {
+            $app['events']->listen(RouteMatched::class, function (RouteMatched $routeMatched) use ( $app ) {
+                $app['newrelic']->nameTransaction( $this->getTransactionName() );
+            });
+        }
+    }
 
-	/**
-	 * Registers the queue transactions with the NewRelic PHP agent
-	 */
-	protected function registerQueueTransactions()
-	{
-		$app = $this->app;
+    /**
+     * Registers the queue transactions with the NewRelic PHP agent
+     */
+    protected function registerQueueTransactions()
+    {
+        $app = $this->app;
 
-		$app['queue']->before(function (JobProcessed $event) use ( $app ) {
-			$app['newrelic']->backgroundJob( true );
-			$app['newrelic']->startTransaction( ini_get('newrelic.appname') );
-			if ($app['config']->get( 'newrelic.auto_name_jobs' )) {
-				$app['newrelic']->nameTransaction( $this->getJobName($event) );
-			}
-		});
+        $app['queue']->before(function (JobProcessing $event) use ( $app ) {
+            $app['newrelic']->backgroundJob( true );
+            $app['newrelic']->startTransaction( ini_get('newrelic.appname') );
+            if ($app['config']->get( 'newrelic.auto_name_jobs' )) {
+                $app['newrelic']->nameTransaction( $this->getJobName($event) );
+            }
+        });
 
-		$app['queue']->after(function (JobProcessed $event) use ( $app ) {
-			$app['newrelic']->endTransaction();
-		});
-	}
+        $app['queue']->after(function (JobProcessed $event) use ( $app ) {
+            $app['newrelic']->endTransaction();
+        });
+    }
 
-	/**
-	 * Build the transaction name
-	 *
-	 * @return string
-	 */
-	public function getTransactionName()
-	{
-		return str_replace(
-			[
-			    '{controller}',
-			    '{method}',
-			    '{route}',
-			    '{path}',
-			    '{uri}',
-			],
-			[
-			    $this->getController(),
-			    $this->getMethod(),
-			    $this->getRoute(),
-			    $this->getPath(),
-			    $this->getUri(),
-			],
-			$this->app['config']->get( 'newrelic.name_provider' )
-		);
-	}
+    /**
+     * Build the transaction name
+     *
+     * @return string
+     */
+    public function getTransactionName()
+    {
+        return str_replace(
+            [
+                '{controller}',
+                '{method}',
+                '{route}',
+                '{path}',
+                '{uri}',
+            ],
+            [
+                $this->getController(),
+                $this->getMethod(),
+                $this->getRoute(),
+                $this->getPath(),
+                $this->getUri(),
+            ],
+            $this->app['config']->get( 'newrelic.name_provider' )
+        );
+    }
 
-	/**
-	 * Build the job name
-	 *
-	 * @return string
-	 */
-	public function getJobName(JobProcessed $event)
-	{
-		return str_replace(
-			[
-			    '{connection}',
-			    '{class}',
-			    '{data}',
-			    '{args}',
-			    '{input}',
-			],
-			[
-			    $event->connectionName,
-			    get_class($event->job),
-			    json_encode($event->data),
-			    implode(', ', array_keys($event->data)),
-			    implode(', ', array_values($event->data)),
-			],
-			$this->app['config']->get( 'newrelic.job_name_provider' )
-		);
-	}
+    /**
+     * Build the job name
+     *
+     * @param JobProcessing $event
+     * @return string
+     */
+    public function getJobName(JobProcessing $event)
+    {
+        return str_replace(
+            [
+                '{connection}',
+                '{class}',
+            ],
+            [
+                $event->connectionName,
+                $event->job->resolveName(),
+            ],
+            $this->app['config']->get( 'newrelic.job_name_provider' )
+        );
+    }
 
-	/**
-	 * Get the request method
-	 *
-	 * @return string
-	 */
-	protected function getMethod()
-	{
-		return strtoupper( $this->app['router']->getCurrentRequest()->method() );
-	}
+    /**
+     * Get the request method
+     *
+     * @return string
+     */
+    protected function getMethod()
+    {
+        return strtoupper( $this->app['router']->getCurrentRequest()->method() );
+    }
 
-	/**
-	 * Get the request URI path
-	 *
-	 * @return string
-	 */
-	protected function getPath()
-	{
-		return ($this->app['router']->current()->uri() == '' ? '/' : $this->app['router']->current()->uri());
-	}
+    /**
+     * Get the request URI path
+     *
+     * @return string
+     */
+    protected function getPath()
+    {
+        return ($this->app['router']->current()->uri() == '' ? '/' : $this->app['router']->current()->uri());
+    }
 
-	protected function getUri()
-	{
-		return $this->app['router']->getCurrentRequest()->path();
-	}
+    protected function getUri()
+    {
+        return $this->app['router']->getCurrentRequest()->path();
+    }
 
-	/**
-	 * Get the current controller / action
-	 *
-	 * @return string
-	 */
-	protected function getController()
-	{
-		$controller = $this->app['router']->current() ? $this->app['router']->current()->getActionName() : 'unknown';
-		if ($controller === 'Closure') {
-			$controller .= '@' . $this->getPath();
-		}
+    /**
+     * Get the current controller / action
+     *
+     * @return string
+     */
+    protected function getController()
+    {
+        $controller = $this->app['router']->current() ? $this->app['router']->current()->getActionName() : 'unknown';
+        if ($controller === 'Closure') {
+            $controller .= '@' . $this->getPath();
+        }
 
-		return $controller;
-	}
+        return $controller;
+    }
 
-	/**
-	 * Get the current route name, or controller if not named
-	 *
-	 * @return string
-	 */
-	protected function getRoute()
-	{
-		$name = $this->app['router']->currentRouteName();
-		if ( !$name )
-		{
-			$name = $this->getController();
-		}
+    /**
+     * Get the current route name, or controller if not named
+     *
+     * @return string
+     */
+    protected function getRoute()
+    {
+        $name = $this->app['router']->currentRouteName();
+        if ( !$name )
+        {
+            $name = $this->getController();
+        }
 
-		return $name;
-	}
+        return $name;
+    }
 }

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -48,9 +48,6 @@ return array(
 	 *      a pattern you define yourself, available tokens:
 	 *          {connection} = The name of the queue connection
 	 *          {class} = The name of the job class
-	 *          {data} = JSON string with all data passed to the job
-	 *          {args} = List of variable names passed to the job
-	 *          {input} = List of values passed to the job
 	 *      anything that is not a matched token will remain a string literal
 	 *      example:
 	 *          Given a job named App\MyJob, with data {"subject":"hello","to":"world"},


### PR DESCRIPTION
Fixes #60 

## Decisions

1. Remove `{data}` `{args} ` and `{input}` from variables that can be used to generate transaction name. All these variables added by PR #48.  Reasons: New events don't have `data` property. It's still possible to fetch and parse them from [->job->payload()](https://github.com/laravel/framework/blob/c7cbd6d24443d7da7fc81ec56935f21b40f45229/src/Illuminate/Contracts/Queue/Job.php#L19) but this is not a good idea (IMO) performance-wise. 
Queue APi has been changed in Laravel 5.3 ([commit](https://github.com/laravel/framework/commit/7db84081186810e4b8da2af6ed51461674ccfb68)). Since this issue fixes an bug added in prev. "patch" version (2.2.1), this fix should be release also as a "patch" version  (2.2.X)